### PR TITLE
Update Rails version

### DIFF
--- a/jstz-rails.gemspec
+++ b/jstz-rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://rubygems.org/gems/jstz-rails"
 
   gem.files         = Dir["{lib,vendor}/**/*"] + ["LICENSE", "README.md"]
-  gem.add_dependency "railties", "~> 3.1"
+  gem.add_dependency "railties", ">= 3.1"
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "jstz-rails"


### PR DESCRIPTION
Given that this is just an asset Gem, is there some merit to just dropping the ~ and switching to a >= 3.1 version check for Rails?
